### PR TITLE
transport: handle unspecified from address

### DIFF
--- a/src/sendmail-transport.js
+++ b/src/sendmail-transport.js
@@ -61,14 +61,19 @@ SendmailTransport.prototype.send = function(mail, callback) {
     mail.message.keepBcc = true;
 
     var envelope = mail.data.envelope || mail.message.getEnvelope(),
-        args = this.args ? this.args.slice() : ['-f'].concat(envelope.from).concat(envelope.to),
+        args,
         sendmail,
         cbCounter = 2,
         didCb,
         marker = 'SendmailTransport.sendMail',
         transform;
 
-    args.unshift('-i'); // force -i to keep single dots
+    if (this.args) {
+        // force -i to keep single dots
+        args = ['-i'].concat(this.args);
+    } else {
+        args = ['-i'].concat(envelope.from ? ['-f', envelope.from] : []).concat(envelope.to);
+    }
 
     try {
         sendmail = this._spawn(this.path, args);


### PR DESCRIPTION
Let sendmail determine which from address to use when it isn't specified from `node mailer`.

Before patch my machine sent messages from `false@redacted.local`, now it sends it from `linus@redacted.local`.
